### PR TITLE
Fix: Resolve Python version and CUDA conflicts for UniRig on ZeroGPU

### DIFF
--- a/unirig_requirements.txt
+++ b/unirig_requirements.txt
@@ -10,14 +10,14 @@ numpy==1.26.4
 # pip knows the version constraint when resolving other dependencies later.
 
 # Make sure torch, torchvision, torch-scatter, etc. are also listed with their correct versions/flags
-torch==2.3.1 --index-url https://download.pytorch.org/whl/cu121
-torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cu121
+torch==2.3.1 --index-url https://download.pytorch.org/whl/cu118
+torchvision==0.18.1 --index-url https://download.pytorch.org/whl/cu118
 
-torch-scatter -f https://data.pyg.org/whl/torch-2.3.1+cu121.html
-torch-cluster -f https://data.pyg.org/whl/torch-2.3.1+cu121.html
+torch-scatter -f https://data.pyg.org/whl/torch-2.3.1+cu118.html
+torch-cluster -f https://data.pyg.org/whl/torch-2.3.1+cu118.html
 
-# Spconv (for CUDA 12.1 - check compatibility with Python 3.11 if issues arise)
-spconv-cu121
+# Spconv (for CUDA 11.8 - check compatibility with Python 3.11 if issues arise)
+spconv-cu118
 
 # Dependencies from UniRig's official requirements.txt
 transformers


### PR DESCRIPTION
This commit addresses runtime errors caused by Python version conflicts between the Gradio environment (Python 3.10) and UniRig/Blender (Python 3.11), and aligns UniRig's dependencies with a CUDA 11.8 environment for Blender processes, likely targeting ZeroGPU compatibility.

Key changes:

1.  **Enhanced Blender Python Diagnostics (`app.py`):**
    *   The diagnostic script executed within Blender's Python environment
        has been significantly enhanced. It now logs:
        *   `sys.executable` and `sys.version` to confirm Python 3.11.
        *   Detailed `sys.path`.
        *   Key environment variables (`PYTHONPATH`, `LD_LIBRARY_PATH`).
        *   Success/failure of importing critical modules: `bpy`, UniRig's
            `src`, `flash_attn`, `spconv`, and `torch` (with CUDA status,
            version, and device info).
    *   This provides better insight into Blender's runtime environment.

2.  **CUDA 11.8 Alignment for Blender's Python:**
    *   `setup_blender.sh` was already installing PyTorch v2.3.1 for CUDA 11.8
        and a specific `flash-attn` wheel compatible with Py3.11/PyTorch2.3/CUDA11.8.
        This strategy has been adopted.
    *   `unirig_requirements.txt` has been modified to align with this:
        *   PyTorch and Torchvision links now point to `cu118` wheels.
        *   PyTorch Geometric (`torch-scatter`, `torch-cluster`) links updated
            for `cu118` (specifically for `torch-2.3.1+cu118`).
        *   `spconv-cu121` changed to `spconv-cu118`.
        *   `flash-attn` remains handled directly by `setup_blender.sh`.

3.  **Robust Blender Invocation (`app.py`):**
    *   The existing mechanisms for invoking Blender via `subprocess.run`,
        including setting a specific environment (`PATH`, `LD_LIBRARY_PATH`,
        `PYTHONPATH`) and using a bootstrap Python script to prepend
        UniRig's directory to `sys.path` within Blender, were reviewed
        and deemed solid.

4.  **Setup Script Verification (`setup_blender.sh`, `app.py`):**
    *   The logic in `app.py` to trigger `setup_blender.sh` if Blender is
        not found, and the script's use of `set -e` and comprehensive
        installation steps, were confirmed to be appropriate.

The overall goal is to ensure that Blender processes use their internal Python 3.11 with a consistent CUDA 11.8 environment for all UniRig-related tasks, resolving the original issue of the wrong Python interpreter being used. The enhanced diagnostics will be key to verifying this in the deployed Space.