### PR TITLE
Fix NameError in diagnostic script generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -414,7 +414,7 @@ print(f"   Is UNIRIG_REPO_DIR ('{os.path.abspath(UNIRIG_REPO_DIR)}') in sys.path
 
 
 unirig_src_dir_in_cwd_exists = os.path.isdir('src')
-print(f"   Is 'src' directory present in CWD ('{{os.getcwd()}}')? {'Yes' if unirig_src_dir_in_cwd_exists else 'No'}")
+print(f"   Is 'src' directory present in CWD ('{{os.getcwd()}}')? {{'Yes' if unirig_src_dir_in_cwd_exists else 'No'}}")
 if unirig_src_dir_in_cwd_exists:
     init_py_in_src_exists = os.path.isfile(os.path.join('src', '__init__.py'))
     print(f"     Is 'src/__init__.py' present? {'Yes' if init_py_in_src_exists else 'No'}")


### PR DESCRIPTION
The variable `unirig_src_dir_in_cwd_exists` was being evaluated prematurely during the construction of the `diagnostic_script_content` string in `app.py`, leading to a `NameError`.

This was resolved by adding an additional pair of curly braces around the conditional f-string expression `{'Yes' if unirig_src_dir_in_cwd_exists else 'No'}`. This ensures that the expression is treated as a literal string during the initial f-string formatting in `app.py` and is only evaluated by the Blender Python interpreter when the diagnostic script is executed.

The corrected line in `app.py` within `diagnostic_script_content` is now:
`print(f"   Is 'src' directory present in CWD ('{{os.getcwd()}}')? {{'Yes' if unirig_src_dir_in_cwd_exists else 'No'}}")`